### PR TITLE
Android_1_Backend-27 전체 회원 리스트 조회 + 팔로잉

### DIFF
--- a/display-service/src/main/java/org/picon/controller/MemberController.java
+++ b/display-service/src/main/java/org/picon/controller/MemberController.java
@@ -2,16 +2,17 @@ package org.picon.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.picon.dto.BaseResponse;
 import org.picon.dto.member.MemberDto;
 import org.picon.dto.member.MemberResponse;
+import org.picon.dto.member.MemberSearchResponse;
 import org.picon.jwt.JwtService;
 import org.picon.service.FeignPostRemoteService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @Validated
@@ -27,5 +28,19 @@ public class MemberController {
         String identityByToken = jwtService.findIdentityByToken(accessToken);
         MemberDto memberDto = feignPostRemoteService.getMember(identityByToken);
         return ResponseEntity.ok().body(new MemberResponse(memberDto));
+    }
+
+    @GetMapping("/member/search")
+    public ResponseEntity<?> searchMember(@RequestParam("input") String input) {
+        List<MemberDto> memberDtos = feignPostRemoteService.searchMember(input);
+        return ResponseEntity.ok().body(new MemberSearchResponse(memberDtos));
+    }
+
+    @PostMapping("/member/follow/{id}")
+    public ResponseEntity<?> follow(@RequestHeader("AccessToken") String accessToken,
+                                    @PathVariable("id") Long followingMemberId) {
+        String identityByToken = jwtService.findIdentityByToken(accessToken);
+        feignPostRemoteService.follow(identityByToken, followingMemberId);
+        return ResponseEntity.ok().body(new BaseResponse());
     }
 }

--- a/display-service/src/main/java/org/picon/dto/member/MemberSearchResponse.java
+++ b/display-service/src/main/java/org/picon/dto/member/MemberSearchResponse.java
@@ -1,0 +1,17 @@
+package org.picon.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.picon.dto.BaseResponse;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberSearchResponse extends BaseResponse {
+    private List<MemberDto> members;
+}

--- a/display-service/src/main/java/org/picon/exception/handler/ExceptionAdvisor.java
+++ b/display-service/src/main/java/org/picon/exception/handler/ExceptionAdvisor.java
@@ -1,6 +1,7 @@
 package org.picon.exception.handler;
 
 import org.picon.dto.BaseResponse;
+import org.picon.exception.BusinessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -29,6 +30,17 @@ public class ExceptionAdvisor {
         String errors = builder.toString();
 
         BaseResponse baseResponse = new BaseResponse(400, errors, "0001", "요청값이 잘못되었습니다.");
+
+        return ResponseEntity.ok().body(baseResponse);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<?> businessException(BusinessException exception) {
+        Throwable cause = exception.getCause();
+
+        String errors = cause.toString();
+
+        BaseResponse baseResponse = new BaseResponse(200, errors, "0003", "로직 오류");
 
         return ResponseEntity.ok().body(baseResponse);
     }

--- a/display-service/src/main/java/org/picon/service/FeignPostRemoteService.java
+++ b/display-service/src/main/java/org/picon/service/FeignPostRemoteService.java
@@ -31,5 +31,11 @@ public interface FeignPostRemoteService {
 
     @GetMapping(path = "/domain/member/")
     MemberDto getMember(@RequestParam("identity") String identity);
+
+    @GetMapping(path = "/domain/member/search")
+    List<MemberDto> searchMember(@RequestParam("input") String input);
+
+    @PostMapping(path = "/domain/member/follow/{id}")
+    void follow(@RequestParam("identity") String identity, @PathVariable("id") Long followMemberId);
 }
 

--- a/display-service/src/main/java/org/picon/service/FeignPostRemoteServiceFallback.java
+++ b/display-service/src/main/java/org/picon/service/FeignPostRemoteServiceFallback.java
@@ -91,4 +91,28 @@ public class FeignPostRemoteServiceFallback implements FeignPostRemoteService {
             throw new BusinessException(cause);
         }
     }
+
+    @Override public List<MemberDto> searchMember(String input) {
+        if (cause instanceof FeignException && ((FeignException) cause).status() == 404) {
+            log.error("404 error took place"
+                    + ". Error message: "
+                    + cause.getLocalizedMessage());
+            throw new RuntimeException(cause);
+        } else {
+            log.error("Other error took place: " + cause.getLocalizedMessage());
+            throw new BusinessException(cause);
+        }
+    }
+
+    @Override public void follow(String identity, Long followMemberId) {
+        if (cause instanceof FeignException && ((FeignException) cause).status() == 404) {
+            log.error("404 error took place"
+                    + ". Error message: "
+                    + cause.getLocalizedMessage());
+            throw new RuntimeException(cause);
+        } else {
+            log.error("Other error took place: " + cause.getLocalizedMessage());
+            throw new BusinessException(cause);
+        }
+    }
 }

--- a/domain-service/src/main/java/org/picon/controller/FollowController.java
+++ b/domain-service/src/main/java/org/picon/controller/FollowController.java
@@ -1,0 +1,32 @@
+package org.picon.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.picon.domain.Member;
+import org.picon.repository.MemberRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.EntityNotFoundException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/domain/member/follow")
+@Transactional(readOnly = true)
+@Slf4j
+public class FollowController {
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/{id}")
+    @Transactional
+    public void follow(@RequestParam("identity") String identity, @PathVariable("id") Long followMemberId) {
+        Member loginMember = memberRepository.findByIdentity(identity)
+                .orElseThrow(EntityNotFoundException::new);
+
+        Member followMember = memberRepository.findById(followMemberId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        loginMember.following(followMember);
+    }
+}

--- a/domain-service/src/main/java/org/picon/controller/MemberController.java
+++ b/domain-service/src/main/java/org/picon/controller/MemberController.java
@@ -6,20 +6,32 @@ import org.modelmapper.*;
 import org.picon.domain.Member;
 import org.picon.dto.MemberDto;
 import org.picon.repository.MemberRepository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/domain/member")
+@Transactional(readOnly = true)
 @Slf4j
 public class MemberController {
     private final ModelMapper modelMapper;
     private final MemberRepository memberRepository;
+
+    @GetMapping("/search")
+    public List<MemberDto> searchMembers(@RequestParam("input") String input) {
+        List<Member> members = memberRepository.searchAll(input);
+        return members.stream()
+                .map(e -> modelMapper.map(e, MemberDto.class))
+                .collect(Collectors.toList());
+    }
 
     @GetMapping("/")
     public MemberDto getMember(@RequestParam("identity") String identity) {

--- a/domain-service/src/main/java/org/picon/domain/Follow.java
+++ b/domain-service/src/main/java/org/picon/domain/Follow.java
@@ -1,0 +1,33 @@
+package org.picon.domain;
+
+import lombok.*;
+import org.hibernate.annotations.NaturalId;
+import org.picon.config.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "FOLLOW")
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Follow extends BaseEntity {
+    @Id @Column(name = "FOLLOW_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID", referencedColumnName = "MEMBER_ID")
+    @NaturalId
+    protected Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "FOLLOW_MEMBER_ID", referencedColumnName = "MEMBER_ID")
+    @NaturalId
+    protected Member followMember;
+
+    public static Follow of(Member member, Member followMember) {
+        return new Follow(null, member, followMember);
+    }
+}

--- a/domain-service/src/main/java/org/picon/domain/Follower.java
+++ b/domain-service/src/main/java/org/picon/domain/Follower.java
@@ -1,0 +1,23 @@
+package org.picon.domain;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class Follower {
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "followMember", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Follow> follows = new ArrayList<>();
+
+    public List<Member> getFollowerMembers() {
+        return follows.stream()
+                .map(e -> e.member)
+                .collect(Collectors.toList());
+    }
+}

--- a/domain-service/src/main/java/org/picon/domain/Followings.java
+++ b/domain-service/src/main/java/org/picon/domain/Followings.java
@@ -1,0 +1,32 @@
+package org.picon.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class Followings {
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Follow> follows = new ArrayList<>();
+
+    protected void following(Member member, Member followMember) {
+        Follow follow = Follow.of(member, followMember);
+        follows.add(follow);
+    }
+
+    public List<Member> getFollowingMembers() {
+        return follows.stream()
+                .map(e -> e.followMember)
+                .collect(Collectors.toList());
+    }
+
+    protected boolean isAlreadyFollwingMember(Member followingMember) {
+        return getFollowingMembers().contains(followingMember);
+    }
+}

--- a/domain-service/src/main/java/org/picon/domain/Member.java
+++ b/domain-service/src/main/java/org/picon/domain/Member.java
@@ -4,21 +4,48 @@ import lombok.*;
 import org.picon.config.BaseEntity;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
 @Table(name = "MEMBERS")
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @Builder
 public class Member extends BaseEntity {
 
     @Id @Column(name = "MEMBER_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
     private String identity;
     private String nickName;
     private String password;
     private String role;
     private String profileImageUrl;
+
+    /**
+     * 내가 팔로우하는 사람들
+     */
+    private Followings followings;
+    /**
+     * 나를 팔로우하는 사람들
+     */
+    private Follower follower;
+
+    public void following(Member followingMember) {
+        if (followings.isAlreadyFollwingMember(followingMember)) {
+            throw new IllegalStateException("이미 팔로잉한 멤버입니다.");
+        }
+        followings.following(this, followingMember);
+    }
+
+    public List<Member> getFollowingMembers() {
+        return followings.getFollowingMembers();
+    }
+
+    public List<Member> getFollowerMembers() {
+        return follower.getFollowerMembers();
+    }
 }

--- a/domain-service/src/main/java/org/picon/repository/MemberRepository.java
+++ b/domain-service/src/main/java/org/picon/repository/MemberRepository.java
@@ -2,9 +2,20 @@ package org.picon.repository;
 
 import org.picon.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIdentity(String identity);
+
+    @Query("select m " +
+            "from Member m " +
+            "where " +
+            "m.nickName like %:input% or " +
+            "m.identity like %:input% ")
+    List<Member> searchAll(@Param("input") String input);
 }

--- a/domain-service/src/test/java/org/picon/controller/FollowControllerTest.java
+++ b/domain-service/src/test/java/org/picon/controller/FollowControllerTest.java
@@ -1,0 +1,55 @@
+package org.picon.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.picon.domain.Follower;
+import org.picon.domain.Member;
+import org.picon.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FollowControllerTest {
+    @Autowired EntityManager entityManager;
+    @Autowired FollowController followController;
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    @Transactional
+    @Rollback
+//    @Commit
+    @DisplayName("로그인 한 회원이 지정한 회원을 팔로우한다.")
+    void follow() {
+        long followMemberId = 1L;
+        String loginId = "id";
+        followController.follow(loginId, followMemberId);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Member loginMember = memberRepository.findByIdentity(loginId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        Member followingMember = memberRepository.findById(followMemberId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        List<Member> followings = loginMember.getFollowingMembers();
+        List<Member> followerMembers = followingMember.getFollowerMembers();
+
+        assertThat(followings).hasSize(1);
+        assertThat(followings.get(0)).isEqualTo(followingMember);
+
+        assertThat(followerMembers).hasSize(1);
+        assertThat(followerMembers.get(0)).isEqualTo(loginMember);
+    }
+
+}


### PR DESCRIPTION
팔로잉 보기, 팔로워 보기, 팔로우하기, 회원 조회 구현했습니다.
직접 레파지토리를 쓰지 않고 일급컬렉션에서 OneToMany를 활용해서 저장시키는 방식으로 했어요.
첨 보시는 형식이실 수도 있는데 나중에 한번 설명드릴게요~ 

그런데 임의로 날리는 exception (EntityNotFoundException, IllegalArgumentException 등)이 feign 클라이언트에서 에러로 인식을 못하네요... 이걸 좀 해결해야할 것 같아요.